### PR TITLE
Update get_employee_yearly_salary

### DIFF
--- a/thai_payroll/custom/employee_tax_exemption_declaration.py
+++ b/thai_payroll/custom/employee_tax_exemption_declaration.py
@@ -383,7 +383,7 @@ def prepare_salary_slip(company, payroll_period, employee, is_opening_entry=None
 def get_employee_yearly_salary(company, payroll_period, employee, is_opening_entry=None, opening_entry_date=None):
 	""" Find most up to date yearly salary, except when on_date is specified """
 	ss = prepare_salary_slip(company, payroll_period, employee, is_opening_entry, opening_entry_date)
-	return ss.ctc
+	return ss.ctc-ss.non_taxable_earnings
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Calculate by ctc - (nontaxable income)

Sorry, I am not sure this works for all of the cases but it works for my case. I am able to include social security as non-taxable income into the salary structure and the tax calculation is correct.